### PR TITLE
Update sponsorship proposal: adjust number of registrations and contr…

### DIFF
--- a/content/events/2025-juiz-de-fora/sponsor.md
+++ b/content/events/2025-juiz-de-fora/sponsor.md
@@ -105,10 +105,10 @@ Visando valorizar a participação de instituições na realização do evento, 
     </tr>
     <tr>
       <td>Inscrições para o evento*</td>
+      <td>1</td>
       <td>3</td>
       <td>8</td>
       <td>10</td>
-      <td>15</td>
     </tr>
     <tr>
       <td><b>Contribuição</b></td>
@@ -120,7 +120,7 @@ Visando valorizar a participação de instituições na realização do evento, 
   </table>
 </div>
 <div>
-  <p><strong>COMUNIDADE:</strong> Apoiadores que contribuiram com algum beneficio para o público ou quantia menor que R$ 1.000,00 terão direito à divulgação nas redes sociais e 1 inscrição para o evento.</p>
+  <p><strong>COMUNIDADE:</strong> Apoiadores que contribuiram com algum beneficio para o público ou quantia menor ou igual a <strong>R$ 500,00</strong> terão direito à divulgação nas redes sociais e 1 inscrição para o evento.</p>
     <!-- <p style="font-size:18px">Veja mais e nosso mídia kit no documento completo clicando <a href="https://docs.google.com/presentation/d/1MzhF2pWpETGvC61k9tpoLmreKbB9yGXGEcv7EWbvLQ0/edit?usp=sharing"><i class="fa fa-download" style="font-size:30px"></i></a></p> -->
 </div>
 


### PR DESCRIPTION
This pull request updates sponsorship details for the 2025 Juiz de Fora event by adjusting the number of event registrations provided for sponsorship tiers and revising the criteria for the "COMUNIDADE" sponsorship category.

### Sponsorship details updates:

* Adjusted the number of event registrations for specific sponsorship tiers in the `content/events/2025-juiz-de-fora/sponsor.md` file. The new numbers are 1, 3, 8, 10, and 15 for the respective tiers.
* Updated the "COMUNIDADE" sponsorship category to include supporters contributing benefits or amounts less than or equal to R$ 500. Previously, this applied to contributions below R$ 1,000.